### PR TITLE
예선)[Fix]: 장바구니 ui 오류수정, 수정/삭제 버튼 클릭 시  상품합계/배송비/총합계에 변경사항 반영

### DIFF
--- a/public/data/cart/cartList.json
+++ b/public/data/cart/cartList.json
@@ -1,5 +1,10 @@
 {
   "data": {
+    "totalPrice": 83700,
+    "totalQantity": 2,
+    "deliveryFee": 0,
+    "orderPrice": 83700,
+    "name": "홍길동",
     "cartList": [
       {
         "id": 8,
@@ -30,81 +35,7 @@
         "price": 43200,
         "quantity": 1,
         "priceByCart": "43200"
-      },
-      {
-        "id": 9,
-        "brandName": "갈비천왕",
-        "itemName": "수원왕갈비",
-        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
-        "options": "왕갈비 400g",
-        "price": 43200,
-        "quantity": 1,
-        "priceByCart": "43200"
-      },
-      {
-        "id": 9,
-        "brandName": "갈비천왕",
-        "itemName": "수원왕갈비",
-        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
-        "options": "왕갈비 400g",
-        "price": 43200,
-        "quantity": 1,
-        "priceByCart": "43200"
-      },
-      {
-        "id": 10,
-        "brandName": "갈비천왕",
-        "itemName": "수원왕갈비",
-        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
-        "options": "왕갈비 400g",
-        "price": 43200,
-        "quantity": 1,
-        "priceByCart": "43200"
-      },
-      {
-        "id": 11,
-        "brandName": "갈비천왕",
-        "itemName": "수원왕갈비",
-        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
-        "options": "왕갈비 400g",
-        "price": 43200,
-        "quantity": 1,
-        "priceByCart": "43200"
-      },
-      {
-        "id": 12,
-        "brandName": "갈비천왕",
-        "itemName": "수원왕갈비",
-        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
-        "options": "왕갈비 400g",
-        "price": 43200,
-        "quantity": 1,
-        "priceByCart": "43200"
-      },
-      {
-        "id": 13,
-        "brandName": "갈비천왕",
-        "itemName": "수원왕갈비",
-        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
-        "options": "왕갈비 400g",
-        "price": 43200,
-        "quantity": 1,
-        "priceByCart": "43200"
-      },
-      {
-        "id": 14,
-        "brandName": "갈비천왕",
-        "itemName": "수원왕갈비",
-        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
-        "options": "왕갈비 400g",
-        "price": 43200,
-        "quantity": 1,
-        "priceByCart": "43200"
       }
-    ],
-    "totalPrice": 83700,
-    "totalQantity": 2,
-    "deliveryFee": 0,
-    "orderPrice": 83700
+    ]
   }
 }

--- a/public/data/cart/cartList.json
+++ b/public/data/cart/cartList.json
@@ -22,6 +22,36 @@
         "priceByCart": "43200"
       },
       {
+        "id": 9,
+        "brandName": "갈비천왕",
+        "itemName": "수원왕갈비",
+        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
+        "options": "왕갈비 400g",
+        "price": 43200,
+        "quantity": 1,
+        "priceByCart": "43200"
+      },
+      {
+        "id": 9,
+        "brandName": "갈비천왕",
+        "itemName": "수원왕갈비",
+        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
+        "options": "왕갈비 400g",
+        "price": 43200,
+        "quantity": 1,
+        "priceByCart": "43200"
+      },
+      {
+        "id": 9,
+        "brandName": "갈비천왕",
+        "itemName": "수원왕갈비",
+        "img": "https://cdn.pixabay.com/photo/2016/03/05/20/07/abstract-1238657__340.jpg",
+        "options": "왕갈비 400g",
+        "price": 43200,
+        "quantity": 1,
+        "priceByCart": "43200"
+      },
+      {
         "id": 10,
         "brandName": "갈비천왕",
         "itemName": "수원왕갈비",

--- a/src/components/Cart/CartItem/CartItem.js
+++ b/src/components/Cart/CartItem/CartItem.js
@@ -3,7 +3,7 @@ import React, { useState, useEffect } from 'react';
 import css from './CartItem.module.scss';
 
 function CartItem({ item, cartList, setCartList }) {
-  const { id, brandName, itemName, img, option } = item;
+  const { id, brandName, itemName, img, options } = item;
   const [count, setCount] = useState(item.quantity);
   const [price, setPrice] = useState(item.price);
   const [itemTotalPrice, setItemTotalPrice] = useState(
@@ -94,7 +94,7 @@ function CartItem({ item, cartList, setCartList }) {
             <div className={css['item-detail-list']}>
               <div className={css['item-select']}>
                 <input type="checkbox"></input>
-                <div className={css['item-option']}>{option}</div>
+                <div className={css['item-option']}>{options}</div>
               </div>
 
               <div>

--- a/src/components/Cart/CartItem/CartItem.js
+++ b/src/components/Cart/CartItem/CartItem.js
@@ -28,7 +28,7 @@ function CartItem({ item, cartList, setCartList }) {
         Authorization: `Bearer ${localStorage.getItem('token')}`,
       },
       body: JSON.stringify({
-        cartsId: 13,
+        cartsId: item.id,
       }),
     })
       .then(res => res.json())
@@ -48,7 +48,7 @@ function CartItem({ item, cartList, setCartList }) {
         Authorization: `Bearer ${localStorage.getItem('token')}`,
       },
       body: JSON.stringify({
-        cartsId: 13,
+        cartsId: item.id,
         quantity: 1,
       }),
     })
@@ -68,7 +68,7 @@ function CartItem({ item, cartList, setCartList }) {
         Authorization: `Bearer ${localStorage.getItem('token')}`,
       },
       body: JSON.stringify({
-        cartsId: 13,
+        cartsId: item.id,
         quantity: -1,
       }),
     })

--- a/src/components/Cart/CartItem/CartItem.js
+++ b/src/components/Cart/CartItem/CartItem.js
@@ -82,8 +82,8 @@ function CartItem({ item, cartList, setCartList }) {
     <>
       <div className={css['cart-item']}>
         <div className={css['item-brand']}>
-          {brandName} (도착일이 같다면 50,000 원 이상 무료 배송 / 현재{' '}
-          {itemTotalPrice.toLocaleString()} 원)
+          {brandName} ( 50,000 원 이상 무료 배송 / 현재{' '}
+          {itemTotalPrice.toLocaleString()} 원 )
         </div>
         <div className={css['item-body']}>
           <img className={css['item-img']} alt={itemName} src={img} />

--- a/src/components/Cart/CartItem/CartItem.js
+++ b/src/components/Cart/CartItem/CartItem.js
@@ -2,13 +2,15 @@ import React, { useState, useEffect } from 'react';
 
 import css from './CartItem.module.scss';
 
-function CartItem({ item, cartList, setCartList }) {
+function CartItem({ item, cartList, setCartList, itemState, setItemState }) {
   const { id, brandName, itemName, img, options } = item;
   const [count, setCount] = useState(item.quantity);
   const [price, setPrice] = useState(item.price);
   const [itemTotalPrice, setItemTotalPrice] = useState(
     Number(`${count * price}`)
   );
+
+  useEffect(() => {}, [count]);
 
   const deliveryFee = 3500;
   const deliveryDate = '2022-09-06';
@@ -35,6 +37,9 @@ function CartItem({ item, cartList, setCartList }) {
       .then(data => {
         console.log(data);
       });
+
+    itemState == true && setItemState(false);
+    itemState == false && setItemState(true);
   };
 
   const countPlus = () => {
@@ -56,26 +61,31 @@ function CartItem({ item, cartList, setCartList }) {
       .then(data => {
         console.log(data);
       });
+    itemState == true && setItemState(false);
+    itemState == false && setItemState(true);
   };
 
   const countMinus = () => {
     count >= 2 && setCount(count - 1);
     count >= 2 && setItemTotalPrice(Number(`${(count - 1) * price}`));
-    fetch('http://localhost:8000/carts', {
-      method: 'PATCH',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${localStorage.getItem('token')}`,
-      },
-      body: JSON.stringify({
-        cartsId: item.id,
-        quantity: -1,
-      }),
-    })
-      .then(res => res.json())
-      .then(data => {
-        console.log(data);
-      });
+    count >= 2 &&
+      fetch('http://localhost:8000/carts', {
+        method: 'PATCH',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('token')}`,
+        },
+        body: JSON.stringify({
+          cartsId: item.id,
+          quantity: -1,
+        }),
+      })
+        .then(res => res.json())
+        .then(data => {
+          console.log(data);
+        });
+    itemState == true && setItemState(false);
+    itemState == false && setItemState(true);
   };
 
   return (

--- a/src/components/Detail/DetailMain/DetailMain.js
+++ b/src/components/Detail/DetailMain/DetailMain.js
@@ -34,7 +34,7 @@ const DetailMain = ({ name, description, slideImgs, content, reviews }) => {
       </div>
 
       <div className={css['img-container']}>
-        <img className={css['main-img']} src={slideImgs[0].img} />
+        <img className={css['main-img']} src={slideImgs[0].image} />
       </div>
       <div>
         <div className={css['content-tab']}>

--- a/src/components/Detail/DetailSub.module.scss
+++ b/src/components/Detail/DetailSub.module.scss
@@ -55,7 +55,7 @@
   }
 
   .option {
-    min-width: 100%;
+    width: 100%;
     height: 45px;
     padding-left: 10px;
     border: 1px solid #bbb;

--- a/src/components/Main/SubSlide/SubSlide.js
+++ b/src/components/Main/SubSlide/SubSlide.js
@@ -7,23 +7,23 @@ function SubSlide(props) {
 
   /////////////목데이터////////////
 
-  useEffect(() => {
-    fetch(`/data/main/${props.query}.json`)
-      .then(res => res.json())
-      .then(res => setImgData(res.data));
-  }, []);
-
-  ///////서버통신///////////
   // useEffect(() => {
-  //   fetch(`http://localhost:8000/products?${props.query}`, {
-  //     method: 'GET',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //     },
-  //   })
+  //   fetch(`/data/main/${props.query}.json`)
   //     .then(res => res.json())
   //     .then(res => setImgData(res.data));
-  // }, [imgData]);
+  // }, []);
+
+  ///////서버통신///////////
+  useEffect(() => {
+    fetch(`http://localhost:8000/products?${props.query}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then(res => res.json())
+      .then(res => setImgData(res.data));
+  }, [imgData]);
 
   const leftBtn = () => {
     if (imgLocation > 0) {

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -9,26 +9,8 @@ function Cart() {
   const [totalDelivery, setTotalDelivery] = useState(0);
   const [totalPrice, setTotalPrice] = useState(0); //배달료 포함 총 금액
 
-  useEffect(() => {
-    fetch('/data/cart/cartList.json')
-      .then(res => res.json())
-      .then(data => {
-        setCartList(data.data.cartList);
-        setItemTotal(data.data.totalPrice);
-        setTotalDelivery(data.data.deliveryFee);
-        setTotalPrice(data.data.orderPrice);
-      });
-  }, []);
-
-  // 장바구니 조회 api
   // useEffect(() => {
-  //   fetch('http://localhost:8000/carts', {
-  //     method: 'GET',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //       Authorization: `Bearer ${localStorage.getItem('token')}`,
-  //     },
-  //   })
+  //   fetch('/data/cart/cartList.json')
   //     .then(res => res.json())
   //     .then(data => {
   //       setCartList(data.data.cartList);
@@ -37,6 +19,24 @@ function Cart() {
   //       setTotalPrice(data.data.orderPrice);
   //     });
   // }, []);
+
+  // 장바구니 조회 api
+  useEffect(() => {
+    fetch('http://localhost:8000/carts', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${localStorage.getItem('token')}`,
+      },
+    })
+      .then(res => res.json())
+      .then(data => {
+        setCartList(data.data.cartList);
+        setItemTotal(data.data.totalPrice);
+        setTotalDelivery(data.data.deliveryFee);
+        setTotalPrice(data.data.orderPrice);
+      });
+  }, []);
 
   return (
     <>
@@ -88,17 +88,17 @@ function Cart() {
                 <div className={css['caption-option']}>도착예정일</div>
                 <div className={css['caption-delete']}>삭제</div>
               </div>
-              {cartList.length &&
-                cartList.map(item => {
-                  return (
-                    <CartItem
-                      key={item.id}
-                      item={item}
-                      cartList={cartList}
-                      setCartList={setCartList}
-                    />
-                  );
-                })}
+
+              {cartList.map(item => {
+                return (
+                  <CartItem
+                    key={item.id}
+                    item={item}
+                    cartList={cartList}
+                    setCartList={setCartList}
+                  />
+                );
+              })}
             </div>
             <div className={css['price-zone']}>
               <div className={css['price-sum']}>

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -88,7 +88,7 @@ function Cart() {
                 <div className={css['caption-option']}>도착예정일</div>
                 <div className={css['caption-delete']}>삭제</div>
               </div>
-              {/* {cartList.length &&
+              {cartList.length &&
                 cartList.map(item => {
                   return (
                     <CartItem
@@ -98,7 +98,7 @@ function Cart() {
                       setCartList={setCartList}
                     />
                   );
-                })} */}
+                })}
             </div>
             <div className={css['price-zone']}>
               <div className={css['price-sum']}>

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -88,7 +88,7 @@ function Cart() {
                 <div className={css['caption-option']}>도착예정일</div>
                 <div className={css['caption-delete']}>삭제</div>
               </div>
-              {cartList.length &&
+              {/* {cartList.length &&
                 cartList.map(item => {
                   return (
                     <CartItem
@@ -98,7 +98,7 @@ function Cart() {
                       setCartList={setCartList}
                     />
                   );
-                })}
+                })} */}
             </div>
             <div className={css['price-zone']}>
               <div className={css['price-sum']}>

--- a/src/pages/Cart/Cart.js
+++ b/src/pages/Cart/Cart.js
@@ -4,7 +4,9 @@ import css from './Cart.module.scss';
 import CartItem from '../../components/Cart/CartItem/CartItem';
 
 function Cart() {
+  const [userName, setUserName] = useState('샘플');
   const [cartList, setCartList] = useState([]);
+  const [itemState, setItemState] = useState(false);
   const [itemTotal, setItemTotal] = useState(''); //전체아이템 총 합계
   const [totalDelivery, setTotalDelivery] = useState(0);
   const [totalPrice, setTotalPrice] = useState(0); //배달료 포함 총 금액
@@ -12,11 +14,13 @@ function Cart() {
   // useEffect(() => {
   //   fetch('/data/cart/cartList.json')
   //     .then(res => res.json())
-  //     .then(data => {
-  //       setCartList(data.data.cartList);
-  //       setItemTotal(data.data.totalPrice);
-  //       setTotalDelivery(data.data.deliveryFee);
-  //       setTotalPrice(data.data.orderPrice);
+  //     .then(req => {
+  //       console.log(req.data);
+  //       setUserName(req.data.name);
+  //       setCartList(req.data.cartList);
+  //       setItemTotal(req.data.totalPrice);
+  //       setTotalDelivery(req.data.deliveryFee);
+  //       setTotalPrice(req.data.orderPrice);
   //     });
   // }, []);
 
@@ -30,13 +34,14 @@ function Cart() {
       },
     })
       .then(res => res.json())
-      .then(data => {
-        setCartList(data.data.cartList);
-        setItemTotal(data.data.totalPrice);
-        setTotalDelivery(data.data.deliveryFee);
-        setTotalPrice(data.data.orderPrice);
+      .then(req => {
+        setUserName(req.data.name);
+        setCartList(req.data.cartList);
+        setItemTotal(req.data.totalPrice);
+        setTotalDelivery(req.data.deliveryFee);
+        setTotalPrice(req.data.orderPrice);
       });
-  }, []);
+  }, [itemState]);
 
   return (
     <>
@@ -44,7 +49,7 @@ function Cart() {
         <div className={css.cart}>
           <div className={css.container}>
             <div className={css['content-header']}>
-              <h1>박예선 님의 장바구니</h1>
+              <h1>{userName} 님의 장바구니</h1>
               <small>주문 예정인 상품을 확인할 수 있습니다.</small>
             </div>
             <ul className={css['order-process']}>
@@ -96,6 +101,8 @@ function Cart() {
                     item={item}
                     cartList={cartList}
                     setCartList={setCartList}
+                    itemState={itemState}
+                    setItemState={setItemState}
                   />
                 );
               })}

--- a/src/pages/Category/Category.js
+++ b/src/pages/Category/Category.js
@@ -11,28 +11,28 @@ function Category() {
   const location = useLocation();
   const navigate = useNavigate();
   /////////////////////목데이터 사용//////////////////////////
-  useEffect(() => {
-    fetch(`/data/category/categoryList.json`)
-      .then(res => res.json())
-      .then(res => {
-        setData(res.data);
-      });
-  }, []);
-  //////////////////////통신 사용////////////////////////
-
   // useEffect(() => {
-  //   fetch(`http://localhost:8000/products${location.search}`, {
-  //     method: 'GET',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //     },
-  //   })
+  //   fetch(`/data/category/categoryList.json`)
   //     .then(res => res.json())
   //     .then(res => {
   //       setData(res.data);
-  //       setCategory(res.data[0].category);
   //     });
-  // }, [location.search]);
+  // }, []);
+  //////////////////////통신 사용////////////////////////
+
+  useEffect(() => {
+    fetch(`http://localhost:8000/products${location.search}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
+      .then(res => res.json())
+      .then(res => {
+        setData(res.data);
+        setCategory(res.data[0].category);
+      });
+  }, [location.search]);
 
   const handleBtn = page => {
     const query = `category=${category}&orderBy=${page}&page=1&pageSize=6`;

--- a/src/pages/Detail/Detail.js
+++ b/src/pages/Detail/Detail.js
@@ -12,26 +12,26 @@ const Detail = () => {
   const { name, description, content, bundles, reviews, fixedprice, images } =
     data;
 
-  // useEffect(() => {
-  //   fetch(`http://localhost:8000/product/${params.id}`, {
-  //     method: 'GET',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //     },
-  //   })
-  //     .then(res => res.json())
-  //     .then(req => {
-  //       setData(req.data);
-  //     });
-  // }, []);
-
   useEffect(() => {
-    fetch('/data/detail/detail.json')
+    fetch(`http://localhost:8000/product/${params.id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
       .then(res => res.json())
       .then(req => {
         setData(req.data);
       });
   }, []);
+
+  // useEffect(() => {
+  //   fetch('/data/detail/detail.json')
+  //     .then(res => res.json())
+  //     .then(req => {
+  //       setData(req.data);
+  //     });
+  // }, []);
 
   return (
     <div className={css.detail}>

--- a/src/pages/Home/Home.js
+++ b/src/pages/Home/Home.js
@@ -11,16 +11,16 @@ function Home() {
       <MainSlide />
 
       {/* //////////목데이터////////// */}
-      <SubSlide query="subSlide">
+      {/* <SubSlide query="subSlide">
         <h2>간편 요리</h2>
         <span>전국 맛집 메뉴를 간단히 요리해보세요</span>
       </SubSlide>
       <SubSlide query="subSlide">
         <h2>주문 많은 순</h2>
-      </SubSlide>
+      </SubSlide> */}
 
       {/* /////////////통신 사용//////////// */}
-      {/* <SubSlide query="category=mealKit">
+      <SubSlide query="category=mealKit">
         <h2>간편 요리</h2>
         <span>전국 맛집 메뉴를 간단히 요리해보세요</span>
       </SubSlide>
@@ -29,7 +29,7 @@ function Home() {
       </SubSlide>
       <SubSlide query="orderBy=viewCount">
         <h2>조회 많은 순</h2>
-      </SubSlide> */}
+      </SubSlide>
     </div>
   );
 }


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [x] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)
- 장바구니 전체적인 오류 수정, 수정/삭제 버튼 클릭 시  상품합계/배송비/총합계도 수정되도록 반영

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 장바구니 상품 없을 때 0 뜨는 오류

&& 연산자를 사용해서 cartlist.length가 true 일 때
상품각각의 컴포넌트를 표시하도록 구현했는데 처음에는 cartlist 의 길이가 0이라서 
그걸 계산해서 표현한 것 같다.  연산자 없이 구현하니 0 뜨는 오류 해결

2. 수정/삭제 버튼 클릭 랜더링을 다시 해서 상품합계, 배송비, 총합계에 수량 반영
수정/삭제 버튼을 클릭했을 때 itemState 라는 state 값이 true <-> false로 
왔다갔다 하며 바뀌게 state 값을 설정하고 그 값이 바뀔때마다 useEffect로 화면을 다시 랜더링.

아쉬운 부분이 많다... 프론트에서 상품합계/배송비 구현을 했으면 랜더링을 다시 안해도 됐을텐데..
나중에 다시 시도해볼 생각이다

<br />

## :: 성장 포인트 (해당 기능을 구현하며 고민했던 사항이나 새로 알게된 부분, 어려웠던 점 등을 작성합니다.)

- 프론트와 백앤드가 서로 필요한 기능을 어떻게 주고받는지 알게되었다.
단순히 첫 랜더링될 때 뿐 아니라 수량이 추가되고 항목이 삭제되는 시점에서 백앤드에
정보를 전달하려면 어떤 위치에서 함수를 작동시켜야하는지 알게되었다. 

<br />
