### PR TITLE
지영) [Add]: 장바구니 담는 수량만큼 Header의 장바구니 수량변화 나타내기

### DIFF
--- a/src/components/Header/Cart.js
+++ b/src/components/Header/Cart.js
@@ -1,14 +1,31 @@
+import React, { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import css from './Cart.module.scss';
 
 function Cart() {
   const navigate = useNavigate();
+  const [cartCount, setCartCount] = useState(0);
+
+  useEffect(() => {
+    fetch('http://localhost:8000/carts', {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${localStorage.getItem('token')}`,
+      },
+    })
+      .then(res => res.json())
+      .then(data => {
+        setCartCount(data.data.cartList.length);
+      });
+  }, []);
+
   return (
     <div className={css['cart-box']} onClick={() => navigate('/cart')}>
       <img src="/image/header/cart.png" alt="cart" />
       <span>장바구니</span>
       <div>
-        <span>0</span>
+        <span>{cartCount}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [x] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 장바구니 담는 수량만큼 Header쪽에 위치한 장바구니 수량변화를 나타내기 (추가되었을 때,)

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)
- 장바구니 조회 api만 가져와, span의 count 초기값 0으로 준 다음, 상품목록의 개수를 불러줄 length를 적용.

<br />

## :: 기타 질문 및 특이 사항

- 그리고, 삭제버튼 눌렀을 때, 장바구니 수량도 변화해야 할 필요가 있습니다.
