### PR TITLE
지영) [Fix]: 로그인 시, 주문시작하지 않았을 때, 마이페이지 메세지 구현 및 point 내역 높이 설정

### DIFF
--- a/src/components/Detail/DetailMain/ReviewList.js
+++ b/src/components/Detail/DetailMain/ReviewList.js
@@ -5,13 +5,20 @@ import css from './ReviewList.module.scss';
 import Review from './Review';
 
 const ReviewList = ({ reviews }) => {
+  console.log({ reviews });
   return (
     <>
-      <div className={css['review-list']}>
-        {reviews.map(review => {
-          return <Review key={review.id} review={review} />;
-        })}
-      </div>
+      {reviews == null ? (
+        <div>
+          <p>조회 가능한 내역이 없습니다.</p>
+        </div>
+      ) : (
+        <div className={css['review-list']}>
+          {reviews.map(review => {
+            return <Review key={review.id} review={review} />;
+          })}
+        </div>
+      )}
     </>
   );
 };

--- a/src/components/Mypage/Orderlist.js
+++ b/src/components/Mypage/Orderlist.js
@@ -16,7 +16,6 @@ function Orderlist() {
     })
       .then(res => res.json())
       .then(data => {
-        console.log(data);
         setOrderListArray(data.data.orderList);
       });
   }, []);

--- a/src/components/Mypage/Orderlist.js
+++ b/src/components/Mypage/Orderlist.js
@@ -6,8 +6,8 @@ function Orderlist() {
   const [orderList, setOrderListArray] = useState([]);
 
   useEffect(() => {
-    // fetch('http://localhost:8000/my', {
-    fetch('/data/myPage/myPage.json', {
+    fetch('http://localhost:8000/my', {
+      // fetch('/data/myPage/myPage.json', {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -16,6 +16,7 @@ function Orderlist() {
     })
       .then(res => res.json())
       .then(data => {
+        console.log(data);
         setOrderListArray(data.data.orderList);
       });
   }, []);
@@ -25,7 +26,7 @@ function Orderlist() {
       <div className={css.sectionTitle}>
         <span>주문 내역</span>
       </div>
-      {orderList.length === 0 ? (
+      {orderList == null ? (
         <div className={css.rowList}>
           <p>조회 가능한 주문 내역이 없습니다.</p>
         </div>

--- a/src/components/Mypage/Point.js
+++ b/src/components/Mypage/Point.js
@@ -6,8 +6,8 @@ function Point() {
   const [point, setPoint] = useState([]);
 
   useEffect(() => {
-    fetch('http://localhost:8000/my', {
-      // fetch('/data/myPage/myPage.json', {
+    // fetch('http://localhost:8000/my', {
+    fetch('/data/myPage/myPage.json', {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/src/components/Mypage/Point.js
+++ b/src/components/Mypage/Point.js
@@ -6,8 +6,8 @@ function Point() {
   const [point, setPoint] = useState([]);
 
   useEffect(() => {
-    // fetch('http://localhost:8000/my', {
-    fetch('/data/myPage/myPage.json', {
+    fetch('http://localhost:8000/my', {
+      // fetch('/data/myPage/myPage.json', {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',
@@ -25,37 +25,43 @@ function Point() {
       <div className={css.sectionTitle}>
         <span>포인트 내역</span>
       </div>
-      <table className={pointCss.orderList}>
-        <thead>
-          <tr className={pointCss.borderBottom}>
-            <th className={pointCss.order}>날짜</th>
-            <th className={pointCss.order}>내역</th>
-            <th className={`${pointCss.order} ${pointCss.thCss}`}>포인트</th>
-          </tr>
-        </thead>
-        <tbody className={pointCss.tdBox}>
-          {point.map(pointHistory => {
-            return (
-              <tr key={pointHistory.pointId}>
-                <td className={`${pointCss.borderBottom} ${pointCss.tdFont}`}>
-                  <span className={pointCss.orderNum}>
-                    {pointHistory.createdAt.substr(0, 10)}
-                  </span>
-                  <div>
-                    <span className={pointCss.orderDate}></span>
-                  </div>
-                </td>
-                <td className={`${pointCss.borderBottom} ${pointCss.tdFont}`}>
-                  {pointHistory.history}
-                </td>
-                <td className={`${pointCss.borderBottom} ${pointCss.tdFont}`}>
-                  {pointHistory.point.toLocaleString()}P
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      {point == null ? (
+        <div className={css.rowList}>
+          <p>조회 가능한 포인트 내역이 없습니다.</p>
+        </div>
+      ) : (
+        <table className={pointCss.orderList}>
+          <thead>
+            <tr className={pointCss.borderBottom}>
+              <th className={pointCss.order}>날짜</th>
+              <th className={pointCss.order}>내역</th>
+              <th className={`${pointCss.order} ${pointCss.thCss}`}>포인트</th>
+            </tr>
+          </thead>
+          <tbody className={pointCss.tdBox}>
+            {point.map(pointHistory => {
+              return (
+                <tr key={pointHistory.pointId}>
+                  <td className={`${pointCss.borderBottom} ${pointCss.tdFont}`}>
+                    <span className={pointCss.orderNum}>
+                      {pointHistory.createdAt.substr(0, 10)}
+                    </span>
+                    <div>
+                      <span className={pointCss.orderDate}></span>
+                    </div>
+                  </td>
+                  <td className={`${pointCss.borderBottom} ${pointCss.tdFont}`}>
+                    {pointHistory.history}
+                  </td>
+                  <td className={`${pointCss.borderBottom} ${pointCss.tdFont}`}>
+                    {pointHistory.point.toLocaleString()}P
+                  </td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      )}
     </div>
   );
 }

--- a/src/components/Mypage/Point.module.scss
+++ b/src/components/Mypage/Point.module.scss
@@ -1,6 +1,7 @@
 .orderList {
   width: 90%;
   margin-left: 50px;
+  margin-bottom: 40px;
   border-top: 0.5px solid #e9e4db;
   border-collapse: collapse;
   font-size: 18px;

--- a/src/components/Mypage/Profile.js
+++ b/src/components/Mypage/Profile.js
@@ -35,8 +35,8 @@ function Profile() {
   // };
 
   useEffect(() => {
-    fetch('/data/myPage/myPage.json', {
-      // fetch('http://localhost:8000/my', {
+    // fetch('/data/myPage/myPage.json', {
+    fetch('http://localhost:8000/my', {
       method: 'GET',
       headers: {
         'Content-Type': 'application/json',

--- a/src/components/Mypage/Review.js
+++ b/src/components/Mypage/Review.js
@@ -28,7 +28,7 @@ function Review() {
       <div className={css.sectionTitle}>
         <span>미식평</span>
       </div>
-      {myReview.length === 0 ? (
+      {myReview == null ? (
         <div className={css.rowList}>
           <p>조회 가능한 미식평이 없습니다.</p>
         </div>

--- a/src/pages/Detail/Detail.js
+++ b/src/pages/Detail/Detail.js
@@ -12,26 +12,26 @@ const Detail = () => {
   const { name, description, content, bundles, reviews, fixedprice, images } =
     data;
 
-  // useEffect(() => {
-  //   fetch(`http://localhost:8000/product/${params.id}`, {
-  //     method: 'GET',
-  //     headers: {
-  //       'Content-Type': 'application/json',
-  //     },
-  //   })
-  //     .then(res => res.json())
-  //     .then(req => {
-  //       setData(req.data);
-  //     });
-  // }, []);
-
   useEffect(() => {
-    fetch('/data/detail/detail.json')
+    fetch(`http://localhost:8000/product/${params.id}`, {
+      method: 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
       .then(res => res.json())
       .then(req => {
         setData(req.data);
       });
   }, []);
+
+  // useEffect(() => {
+  //   fetch('/data/detail/detail.json')
+  //     .then(res => res.json())
+  //     .then(req => {
+  //       setData(req.data);
+  //     });
+  // }, []);
 
   return (
     <div className={css.detail}>

--- a/src/pages/Mypage/Mypage.js
+++ b/src/pages/Mypage/Mypage.js
@@ -18,38 +18,11 @@ function Mypage() {
   const [name, setName] = useState('');
 
   ////최종 목데이터로 마이미식 데이터 get api
-  useEffect(() => {
-    fetch('/data/myPage/myPage.json', {
-      method: 'GET',
-      headers: {
-        Authorization: localStorage.getItem('token'),
-        'Content-Type': 'application/json',
-      },
-    })
-      .then(res => res.json())
-      .then(req => {
-        {
-          let pointArr = req.data.point;
-          let totalPoint = 0;
-          pointArr.forEach(point => {
-            totalPoint = totalPoint + point.point;
-          }); //통합데이터에서 point값만 더해서 totalPoint를 구한 후 보여줌
-          setUserInfo({
-            ...userInfo,
-            name: req.data.name,
-            profileImg: req.data.profilePicture,
-            point: totalPoint,
-          });
-        }
-      });
-  }, []);
-
-  ////////////마이메이지 마이미식 get api/////////
   // useEffect(() => {
-  //   fetch('http://localhost:8000/my', {
+  //   fetch('/data/myPage/myPage.json', {
   //     method: 'GET',
   //     headers: {
-  //       Authorization: `Bearer ${localStorage.getItem('token')}`,
+  //       Authorization: localStorage.getItem('token'),
   //       'Content-Type': 'application/json',
   //     },
   //   })
@@ -70,6 +43,33 @@ function Mypage() {
   //       }
   //     });
   // }, []);
+
+  ////////////마이메이지 마이미식 get api/////////
+  useEffect(() => {
+    fetch('http://localhost:8000/my', {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('token')}`,
+        'Content-Type': 'application/json',
+      },
+    })
+      .then(res => res.json())
+      .then(req => {
+        {
+          let pointArr = req.data.point;
+          let totalPoint = 0;
+          pointArr.forEach(point => {
+            totalPoint = totalPoint + point.point;
+          }); //통합데이터에서 point값만 더해서 totalPoint를 구한 후 보여줌
+          setUserInfo({
+            ...userInfo,
+            name: req.data.name,
+            profileImg: req.data.profilePicture,
+            point: totalPoint,
+          });
+        }
+      });
+  }, []);
   //////////////////
 
   const mypageChangeTab = e => {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 로그인 시, 주문시작하지 않았을 때, 마이페이지에서 각각 주문내역, 리뷰내역, 포인트 탭에서 '조회 가능한 () 내역이 없습니다'라고 메세지 구현하기 <------ 삼항 연산자 사용
- point 탭에서 내역 끝의 밑 높이 조절하기 <----- margin-bottom 사용

+ 추가사항
포인트 내역에서 div로만 되어있던 태그에 클래스이름을 줘서 min-height: 350px로 설정해주시면 됩니다.
내 정보 들어가면, 회원가입한 정보들이 안 불러오진다는 점.