### PR TITLE
예선)[Fix]: 로그아웃 클릭 시 헤더 장바구니 숫자 0으로 변화

### DIFF
--- a/src/components/Header/Login.js
+++ b/src/components/Header/Login.js
@@ -9,6 +9,7 @@ function Login({ setCartCount }) {
     localStorage.removeItem('token');
     token ? setToken(false) : setToken(true);
     navigate('/');
+    window.location.replace('/');
     alert('로그아웃 되었습니다.');
     setCartCount(0);
   };

--- a/src/pages/Login/Login.js
+++ b/src/pages/Login/Login.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import css from './Login.module.scss';
 import LogoBox from '../../components/SignupLogin/LogoBox';
-import Header from '../../components/Header/Header';
 
 function Login() {
   const navigate = useNavigate();

--- a/src/pages/Router.js
+++ b/src/pages/Router.js
@@ -23,7 +23,7 @@ import Footer from '../components/Footer/Footer';
 function Router() {
   const [cartCount, setCartCount] = useState(0);
 
-  useEffect(() => {
+  localStorage.getItem('token') && // useEffect(() => {
     fetch('http://localhost:8000/carts', {
       method: 'GET',
       headers: {
@@ -34,8 +34,7 @@ function Router() {
       .then(res => res.json())
       .then(data => {
         setCartCount(data.data.cartList.length);
-      });
-  }, [cartCount]);
+      }); // }, [cartCount]);
 
   return (
     <BrowserRouter>


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)

- [ ] 레이아웃 구현
- [x] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 (해당 브랜치에서 구현하고자 하는 하나의 목표를 설정합니다.)

- 헤더부분 장바구니 옆 숫자가 로그아웃하면 초기화되도록 설정

<br />

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. 로그아웃 버튼을 누르면 새로고침이 되면서 메인으로 이동하도록  window.location.replace('/'); 선언

<br />
